### PR TITLE
Fix duplicate of current contestant's team on dashboard

### DIFF
--- a/portal/app/javascript/ApiClient.ts
+++ b/portal/app/javascript/ApiClient.ts
@@ -231,7 +231,7 @@ export class ApiClient {
       : audienceBoard.leaderboard!.teams!;
 
     const idx = dest.findIndex((v) => v.team!.id === contestantLeaderboardItem.team!.id);
-    if (idx) {
+    if (idx >= 0) {
       dest.splice(idx, 1, contestantLeaderboardItem);
     } else {
       dest.push(contestantLeaderboardItem);

--- a/portal/app/javascript/Leaderboard.tsx
+++ b/portal/app/javascript/Leaderboard.tsx
@@ -2,7 +2,7 @@ import type { isuxportal } from "./pb";
 import React from "react";
 
 import { Timestamp } from "./Timestamp";
-import type { TeamPinsMap, TeamPins } from "./TeamPins";
+import type { TeamPinsMap } from "./TeamPins";
 
 const NUMBER_OF_ROWS_VISIBLE_BY_DEFAULT = 25;
 
@@ -129,7 +129,7 @@ export const Leaderboard: React.FC<Props> = (props: Props) => {
     })
   );
   const prevScores = new Map(
-    (prevFilteredTeams || []).map((t, idx) => {
+    (prevFilteredTeams || []).map((t) => {
       return [t.team!.id, t.latestScore?.score!];
     })
   );


### PR DESCRIPTION
Fix:

![screenshot of reproduce](https://img.sorah.jp/x/20220826_072441_BPfpEU4W35.png)

findIndex returns -1 when not found, and 0 is falsy on JavaScript.


ApiClient.getContestantMergedDashboard had unintentionally returned a
 leaderboard contains the team logged in twice, when the team is at the 1st position. This triggers duplicated  React node key where use team ID directly and its undefined behavior.

Steps to reproduce:

- when the team logged in is at 1st position on a leaderboard
- clicks General/Students tab to switch mode